### PR TITLE
Demo API - first front end to back end request

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "5.0.1",
@@ -4587,6 +4588,28 @@
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -19533,6 +19556,27 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1",

--- a/client/src/API/demo.api.js
+++ b/client/src/API/demo.api.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+export const getDemoData = async () => {
+    try {
+        const demo = await axios.get('http://localhost:8080/demo');
+        return demo;
+    } catch (error) {
+        console.log(error);
+    }
+}

--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -1,11 +1,13 @@
-import React from "react"
+import React from "react";
+import DemoData from '../DemoComponent';
 
 function App () {
     return (
         <div className="App">
             <h1>Ingredient Tracker Landing Page</h1>
+            < DemoData />
         </div>
     );
-}
+};
 
 export default App;

--- a/client/src/components/DemoComponent.jsx
+++ b/client/src/components/DemoComponent.jsx
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from 'react';
+import { getDemoData } from '../API/demo.api';
+
+const DemoData = () => {
+    const [demo, setDemoData] = useState([]);
+
+    useEffect( async () => {
+        const response = await getDemoData();
+        if (response != null) {
+            console.log(response);
+            setDemoData(response.data)
+        }
+    }, [])
+
+    return (
+        <div>
+            <ol>
+            {demo.map(d => {
+                return <li>Name: {d.name}, Type: {d.type}</li>
+            })}
+            </ol>
+        </div>
+    )
+};
+
+export default DemoData;

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "nodemon index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Added a demo API in client directory to make request from front end to back end and display it on the App.js.
For now, "npm start" command has to be run in both the server folder and the client folder to make sure the server is up and running so that the landing page can get and visualize the demo data. If server doesn't run only the H1 will be shown - Aljoscha

![220529_Capture](https://user-images.githubusercontent.com/101998855/170891350-8bdc8b7d-b3ca-4efa-a0a3-a62495bb3803.PNG)
